### PR TITLE
fix: ロゴ画像の高さ指定を修正

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,7 +33,7 @@ export default function RootLayout({
 				<header className="bg-gray-800 text-white p-4">
 					<div className="container mx-auto flex justify-between items-center">
 						<Link href="/" className="flex items-center gap-2 text-xl font-bold">
-							<Image src="/logo/logo.webp" alt="Logo" width={32} height={32} />
+							<Image src="/logo/logo.webp" alt="Logo" width={32} height={46} />
 							{SiteConfig.name}
 						</Link>
 						<nav className="flex items-center gap-6">


### PR DESCRIPTION
Closes #44

## やったこと
- ロゴ画像の縦横比を正しく表示するため、height属性を46に変更

## 確認手順
- ブラウザでページを開いて、ヘッダーのロゴ画像が正しい縦横比で表示されていることを確認
- 異なるスクリーンサイズで表示を確認

## GitHub ISSUE
https://github.com/nikawa2161/blog/issues/44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **UI改善**
  * サイトヘッダーのロゴ画像のサイズを更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->