### PR TITLE
CLAUDE.mdにGitHub操作セクションを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,10 +30,11 @@ bun run lint
 - コミットメッセージ規約: @doc/commit-convention.md
 - treeコマンドとREADME.md更新: @doc/tree-command.md（構造変更時にtreeコマンドを実行してREADME.mdを更新）
 
-## PR作成
+## GitHub操作
 
-`.claude/commands/pr.md` のコマンドを使用してPRを作成できます。
-ブランチ名から自動的にGitHub ISSUEを取得し、PRを作成します。
+- **ISSUE作成**: `gh issue create` コマンドを使用
+- **PR作成**: `.claude/commands/pr.md` のコマンドを使用
+  - ブランチ名から自動的にGitHub ISSUEを取得し、PRを作成します
 
 ## 注意事項
 


### PR DESCRIPTION
## ISSUEのリンク

* https://github.com/nikawa2161/blog/issues/48

## やったこと

* 「PR作成」セクションを「GitHub操作」に変更
* ISSUE作成にはgh issue createコマンドを使用することを明記
* MCP GitHub APIではなくgh CLIを使用する方針を明確化

## やらないこと

* 無し

## できるようになること

* 無し

## できなくなること

* 無し

## 動作確認

* ドキュメント変更のみのため、ビルドとlintで検証

## その他

Resolves #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * GitHub関連の操作手順を再編成し、新たに"GitHub操作"セクションを追加しました。
  * Issue作成コマンド（gh issue create）の使用方法を追加しました。
  * ブランチ名からGitHub Issueを自動取得してPRを作成する機能について説明を追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->